### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,14 +11,14 @@ The ``fat`` module is required to run code optimized by ``fatoptimizer`` if
 at least one function is specialized.
 
 * `fat documentation
-  <https://fatoptimizer.readthedocs.org/en/latest/fat.html>`_
+  <https://fatoptimizer.readthedocs.io/en/latest/fat.html>`_
 * `fat project at GitHub
   <https://github.com/haypo/fat>`_
 * `fat project at the Python Cheeseshop (PyPI)
   <https://pypi.python.org/pypi/fat>`_
 * `fatoptimizer documentation
-  <https://fatoptimizer.readthedocs.org/>`_
+  <https://fatoptimizer.readthedocs.io/>`_
 * `FAT Python
-  <https://faster-cpython.readthedocs.org/fat_python.html>`_
+  <https://faster-cpython.readthedocs.io/fat_python.html>`_
 
 The ``fat`` module requires a Python 3.6 patched with PEP 510 patch.

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ def main():
         'license': 'MIT license',
         'description': 'Fast guards used by fatoptimizer to specialize functions',
         'long_description': long_description,
-        "url": "https://fatoptimizer.readthedocs.org/en/latest/fat.html",
+        "url": "https://fatoptimizer.readthedocs.io/en/latest/fat.html",
         'author': 'Victor Stinner',
         'author_email': 'victor.stinner@gmail.com',
         'ext_modules': [ext],


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
